### PR TITLE
alter CREATE TABLE script - Fixes #1938

### DIFF
--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -541,7 +541,7 @@ IF OBJECT_ID('tempdb..#FilteredIndexes') IS NOT NULL
                         CASE WHEN equality_columns IS NOT NULL AND inequality_columns IS NOT NULL THEN N'_' ELSE N'' END
                         + ISNULL(inequality_columns,''),',','')
                         ,'[',''),']',''),' ','_') 
-                    + CASE WHEN included_columns IS NOT NULL THEN N'_includes' ELSE N'' END + N'] ON ' 
+                    + CASE WHEN included_columns IS NOT NULL THEN N'_Includes' ELSE N'' END + N'] ON ' 
                     + [statement] + N' (' + ISNULL(equality_columns,N'')
                     + CASE WHEN equality_columns IS NOT NULL AND inequality_columns IS NOT NULL THEN N', ' ELSE N'' END
                     + CASE WHEN inequality_columns IS NOT NULL THEN inequality_columns ELSE N'' END + 

--- a/sp_BlitzIndex.sql
+++ b/sp_BlitzIndex.sql
@@ -535,7 +535,7 @@ IF OBJECT_ID('tempdb..#FilteredIndexes') IS NOT NULL
                     END + CASE WHEN included_columns IS NOT NULL THEN N'INCLUDES: ' + included_columns + N' '
                         ELSE N''
                     END,
-                [create_tsql] AS N'CREATE INDEX [ix_' + table_name + N'_' 
+                [create_tsql] AS N'CREATE INDEX [IX_ 
                     + REPLACE(REPLACE(REPLACE(REPLACE(
                         ISNULL(equality_columns,N'')+ 
                         CASE WHEN equality_columns IS NOT NULL AND inequality_columns IS NOT NULL THEN N'_' ELSE N'' END


### PR DESCRIPTION
Fixes #1938 .

Changes proposed in this pull request:
 - Alter CREATE TABLE script to remove table name
 - also corrected capitalization

How to test this code:
 - run BlitzIndex and check the 'create index' scripts


Has been tested on (remove any that don't apply):
